### PR TITLE
feat: Implement ActivityPub Zod schemas for Mastodon models

### DIFF
--- a/src/accept.ts
+++ b/src/accept.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { Follow } from "./follow.js"; // Follow activity schema
+import { BaseObjectSchema } from "./note/baseContent.js"; // Or a more generic object/link type
 
-import { Follow } from "./follow.js";
+const AcceptedObject = z.union([
+  Follow,
+  BaseObjectSchema, // e.g. accepting a friend request represented by an Offer activity
+  z.string().url() // URL to an object being accepted
+]);
 
-export const Accept = z.object({
-  id: z.string(),
-  actor: z.string(),
+export const AcceptActivity = BaseActivity.extend({
   type: z.literal("Accept"),
-  object: Follow,
+  object: AcceptedObject.describe("The object that was accepted (e.g., a Follow activity, an Offer)."),
 });
 
-export type Accept = z.infer<typeof Accept>;
+export type AcceptActivity = z.infer<typeof AcceptActivity>;

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { Actor } from "./actor.js"; // Assuming Actor schema is defined
+import { BaseObjectSchema } from "./note/baseContent.js"; // Assuming a base object schema
+
+// A generic reference to an object or link, can be a URI or an embedded object
+const ObjectOrLink = z.union([z.string().url(), BaseObjectSchema, Actor]);
+const LinkReference = z.string().url(); // For actor, object, target if only expecting URI
+
+export const BaseActivity = z.object({
+  "@context": z
+    .union([
+      z.string().url(),
+      z.array(z.union([z.string().url(), z.record(z.string())])),
+    ])
+    .optional()
+    .describe("The JSON-LD context"),
+  id: z.string().url().describe("Unique URI for the activity"),
+  type: z.string().describe("The type of the activity"), // To be specialized by extending schemas
+
+  actor: ObjectOrLink.describe("The actor performing the activity (URI or Actor object)"),
+
+  object: ObjectOrLink.optional().describe("The object of the activity (URI or AP Object)"),
+
+  target: ObjectOrLink.optional().describe("The target of the activity (URI or AP Object)"),
+
+  published: z.string().datetime({ offset: true }).optional().describe("Publication date of the activity (ISO 8601)"),
+
+  to: z.array(LinkReference).optional().describe("Audience: Primary recipients"),
+  cc: z.array(LinkReference).optional().describe("Audience: Copied recipients"),
+  bto: z.array(LinkReference).optional().describe("Audience: Blind carbon copy (for C2S)"),
+  bcc: z.array(LinkReference).optional().describe("Audience: Blind carbon copy (for C2S)"),
+
+  summary: z.string().optional().describe("A summary of the activity"),
+  content: z.string().optional().describe("Content of the activity, if any"),
+
+  // instrument: ObjectOrLink.optional().describe("Tool or instrument used in the activity"),
+  // origin: ObjectOrLink.optional().describe("Origin of the activity"),
+  // result: ObjectOrLink.optional().describe("Result of the activity"),
+});
+
+export type BaseActivity = z.infer<typeof BaseActivity>;

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -1,36 +1,105 @@
 import { z } from "zod";
 import { Image } from "./image.js";
+import { PropertyValue } from "./note/propertyValue.js";
+// Assuming a generic Collection schema exists or will be created, e.g., in ./collection.ts
+// For now, we'll use z.string().url() for collection URIs
+// import { Collection } from "./collection.js";
+// import { Tag } from "./note/tag.js"; // For featuredTags item type
+
+export const ActorType = z.union([
+  z.literal("Person"),
+  z.literal("Service"),
+  z.literal("Application"),
+  z.literal("Group"),
+  z.literal("Organization"), // Added based on common ActivityPub types
+]);
+export type ActorType = z.infer<typeof ActorType>;
+
+export const PublicKey = z.object({
+  id: z.string().describe("Key ID"),
+  owner: z.string().url().describe("Owner of the key (actor URL)"),
+  publicKeyPem: z.string().describe("PEM encoded public key"),
+});
+export type PublicKey = z.infer<typeof PublicKey>;
+
+export const ActorEndpoints = z.object({
+  sharedInbox: z.string().url().optional().describe("URL of the shared inbox"),
+  // As per ActivityPub spec, other endpoints can also be listed here.
+  // Example: uploadMedia: z.string().url().optional().describe("Endpoint for uploading media")
+});
+export type ActorEndpoints = z.infer<typeof ActorEndpoints>;
 
 export const Actor = z.object({
-  id: z.string(),
-  type: z.union([z.literal("Person"), z.literal("Service")]),
-  following: z.string().url().optional(),
-  followers: z.string().url(),
-  inbox: z.string().url(),
-  outbox: z.string().url(),
-  preferredUsername: z.string(),
-  name: z.string(),
-  summary: z.string().nullish(),
-  url: z.string().url(),
-  published: z.string().nullish(),
-  manuallyApprovesFollowers: z.boolean().optional(),
-  publicKey: z.object({
-    id: z.string(),
-    owner: z.string(),
-    publicKeyPem: z.string(),
-  }),
-  endpoints: z
-    .object({
-      sharedInbox: z.string().url().optional(),
-    })
-    .optional(),
-  icon: Image.nullish(),
-  image: Image.nullish(),
+  "@context": z
+    .union([
+      z.string(),
+      z.array(z.union([z.string(), z.record(z.string())])),
+    ])
+    .optional()
+    .describe(
+      "The JSON-LD context. Can be a URL or an array of URLs/objects."
+    ),
+  id: z.string().url().describe("The unique URI of the actor"),
+  type: ActorType,
+  following: z.string().url().optional().describe("URI of the collection of actors this actor is following"),
+  followers: z.string().url().optional().describe("URI of the collection of actors followers of this actor"),
+  inbox: z.string().url().describe("URI of the actor's inbox for receiving activities"),
+  outbox: z.string().url().describe("URI of the actor's outbox for sending activities"),
+  preferredUsername: z.string().optional().describe("The actor's preferred username"),
+  name: z.string().optional().describe("The actor's display name"),
+  summary: z.string().nullish().describe("A summary or bio of the actor"),
+  url: z.string().url().optional().describe("A URL linking to a page representing the actor"),
+  published: z.string().datetime({ offset: true }).nullish().describe("The date and time the actor was created (ISO 8601)"),
+  updated: z.string().datetime({ offset: true }).nullish().describe("The date and time the actor was last updated (ISO 8601)"),
+
+  manuallyApprovesFollowers: z.boolean().optional().describe("Does this actor manually approve followers? (as:manuallyApprovesFollowers)"),
+
+  publicKey: PublicKey.optional().describe("The actor's public key (sec:publicKey)"),
+
+  endpoints: ActorEndpoints.optional().describe("A map of additional endpoints for the actor"),
+
+  icon: Image.nullish().describe("An image icon for the actor (e.g., avatar)"),
+  image: Image.nullish().describe("An image banner for the actor (e.g., header)"),
+
+  attachment: z.array(PropertyValue).optional().describe("Profile metadata as an array of PropertyValue (schema:PropertyValue)"),
+
+  discoverable: z.boolean().optional().describe("Opt-in to discovery features (toot:discoverable)"),
+  indexable: z.boolean().optional().describe("Opt-in to search engine indexing (toot:indexable). Note: Mastodon uses 'noindex' in its API which is the inverse."),
+  suspended: z.boolean().optional().describe("Whether the account is suspended (toot:suspended)"),
+  memorial: z.boolean().optional().describe("Whether the account is a memorial account (toot:memorial)"),
+
+  featured: z.string().url().optional().describe("URI of a collection of featured objects/statuses (toot:featured)"),
+  // featured: z.lazy(() => Collection.extend({ items: z.array(z.union([Status, z.string().url()])) })).optional(), // More specific if Status schema is available
+
+  featuredTags: z.string().url().optional().describe("URI of a collection of featured tags (toot:featuredTags)"),
+  // featuredTags: z.lazy(() => Collection.extend({ items: z.array(Tag) })).optional(), // More specific if Tag schema is available
+
+  alsoKnownAs: z.array(z.string().url()).optional().describe("A list of URIs of other actors affiliated with this actor (for migration, etc.)"),
+  movedTo: z.string().url().optional().describe("URI of the new actor this account has moved to (as:movedTo)"),
 });
 export type Actor = z.infer<typeof Actor>;
 
-export const Person = Actor;
+export const Person = Actor.extend({
+  type: z.literal("Person"),
+});
 export type Person = z.infer<typeof Person>;
 
-export const Service = Actor;
+export const Service = Actor.extend({
+  type: z.literal("Service"),
+});
 export type Service = z.infer<typeof Service>;
+
+export const Application = Actor.extend({
+  type: z.literal("Application"),
+});
+export type Application = z.infer<typeof Application>;
+
+export const Group = Actor.extend({
+  type: z.literal("Group"),
+});
+export type Group = z.infer<typeof Group>;
+
+export const Organization = Actor.extend({
+  type: z.literal("Organization"),
+});
+export type Organization = z.infer<typeof Organization>;

--- a/src/add.ts
+++ b/src/add.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js";
+import { Actor } from "./actor.js";
+import { Collection } from "./collection.js"; // Target is often a collection
+
+const AddedObject = z.union([BaseObjectSchema, Actor, z.string().url()]);
+const TargetCollection = z.union([Collection, z.string().url()]);
+
+export const AddActivity = BaseActivity.extend({
+  type: z.literal("Add"),
+  object: AddedObject.describe("The object being added."),
+  target: TargetCollection.optional().describe("The collection to which the object is being added."),
+});
+
+export type AddActivity = z.infer<typeof AddActivity>;

--- a/src/announce.ts
+++ b/src/announce.ts
@@ -1,13 +1,19 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // Or a more generic object/link type
+import { Actor } from "./actor.js";
 
-export const Announce = z.object({
+// The object of an Announce can be an object or a link to an object.
+const AnnouncedObject = z.union([
+  z.string().url(),
+  BaseObjectSchema,
+  Actor // e.g. Announcing a profile
+]);
+
+export const AnnounceActivity = BaseActivity.extend({
   type: z.literal("Announce"),
-  id: z.string(),
-  actor: z.string(),
-
-  published: z.string({ description: "Object published datetime" }),
-  to: z.union([z.string(), z.string().array()]),
-  cc: z.union([z.string(), z.string().array()]),
-  object: z.string(),
+  object: AnnouncedObject.describe("The object that is being announced/boosted."),
+  // published, to, cc are inherited from BaseActivity
 });
-export type Announce = z.infer<typeof Announce>;
+
+export type AnnounceActivity = z.infer<typeof AnnounceActivity>;

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { Actor } from "./actor.js"; // Object of a block is an Actor or its URI
+
+const BlockedObject = z.union([
+  Actor,
+  z.string().url() // URI of the actor being blocked
+]);
+
+export const BlockActivity = BaseActivity.extend({
+  type: z.literal("Block"),
+  object: BlockedObject.describe("The actor that is being blocked."),
+  // Mastodon S2S Block:
+  // actor: "https://mastodon.example/users/alice",
+  // object: "https://example.com/~mallory",
+  // to: "https://example.com/~mallory" (The actor being blocked)
+});
+
+export type BlockActivity = z.infer<typeof BlockActivity>;
+
+// Make sure this is imported in undo.ts if used with z.lazy()
+// For example, in undo.ts:
+// import { BlockActivity } from "./block.js";
+// const UndoneActivity = z.union([..., z.lazy(() => BlockActivity), ...]);
+// This is now fine as block.ts does not depend on undo.ts

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,27 +1,106 @@
 import { z } from "zod";
 
-export const CollectionWithFirstPage = z.object({
-  id: z.string(),
-  type: z.literal("Collection"),
-  first: z.object({
-    type: z.literal("CollectionPage"),
-    next: z.string(),
-    partOf: z.string(),
-    items: z.union([z.any(), z.array(z.any())]),
-  }),
-});
-export type CollectionWithFirstPage = z.infer<typeof CollectionWithFirstPage>;
+// Define a generic item type for collections.
+// Can be a URL string or any Zod schema (e.g., Actor, Note, LikeActivity).
+const ItemSchema = z.union([z.string().url(), z.any()]); // z.any() will be replaced by a generic in the functions
 
-export const CollectionWithItems = z.object({
-  id: z.string(),
-  type: z.literal("Collection"),
-  totalItems: z.number(),
-  items: z.union([z.any(), z.array(z.any())]),
+export const CollectionType = z.union([
+  z.literal("Collection"),
+  z.literal("OrderedCollection"),
+]);
+export type CollectionType = z.infer<typeof CollectionType>;
+
+export const CollectionPageType = z.union([
+  z.literal("CollectionPage"),
+  z.literal("OrderedCollectionPage"),
+]);
+export type CollectionPageType = z.infer<typeof CollectionPageType>;
+
+// Generic function to create a CollectionPage schema for a given item type
+export function createCollectionPageSchema<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z.object({
+    "@context": z.union([z.string().url(), z.array(z.union([z.string().url(), z.record(z.string())]))]).optional(),
+    id: z.string().url().optional().describe("Unique URI for the collection page"), // Page ID is optional
+    type: CollectionPageType,
+    partOf: z.string().url().optional().describe("URI of the collection this page belongs to"), // Optional as per AP spec
+    next: z.string().url().optional().describe("URI of the next page in the collection"),
+    prev: z.string().url().optional().describe("URI of the previous page in the collection"),
+    items: z.array(itemSchema).optional().describe("The items contained in this page"),
+    // Other properties like totalItems can also be on a page
+    totalItems: z.number().int().nonnegative().optional().describe("Total items in the collection (can also be on the page)"),
+    current: z.string().url().optional().describe("Link to this page (self-reference)"),
+    first: z.string().url().optional().describe("Link to the first page (if different from current)"),
+    last: z.string().url().optional().describe("Link to the last page"),
+  });
+}
+
+// Generic function to create a Collection schema for a given item type
+export function createCollectionSchema<T extends z.ZodTypeAny>(itemSchema: T) {
+  const collectionPageSchema = createCollectionPageSchema(itemSchema);
+
+  return z.object({
+    "@context": z.union([z.string().url(), z.array(z.union([z.string().url(), z.record(z.string())]))]).optional(),
+    id: z.string().url().describe("Unique URI for the collection"),
+    type: CollectionType,
+    totalItems: z.number().int().nonnegative().optional().describe("Total number of items in the collection"),
+
+    // Direct items (for non-paginated or embedded collections)
+    items: z.array(itemSchema).optional().describe("Items in the collection if not paginated or if first page is embedded"),
+
+    // For paginated collections
+    first: z.union([z.string().url(), collectionPageSchema]).optional().describe("The first page of items or a link to it"),
+    last: z.string().url().optional().describe("The last page of items or a link to it"),
+    current: z.string().url().optional().describe("A link to the current page (if collection itself represents a page)"),
+
+    // Other possible properties
+    name: z.string().optional().describe("A name for the collection"),
+    summary: z.string().optional().describe("A summary of the collection"),
+  });
+}
+
+// Example of a generic Collection (can hold any item type if not specified)
+export const BaseCollection = createCollectionSchema(ItemSchema);
+export type BaseCollection = z.infer<typeof BaseCollection>;
+
+// Example of a generic CollectionPage
+export const BaseCollectionPage = createCollectionPageSchema(ItemSchema);
+export type BaseCollectionPage = z.infer<typeof BaseCollectionPage>;
+
+
+// --- Pre-generic version for reference or simpler use cases ---
+// This is what was present before making it generic. Kept for context if needed.
+// export const OldCollectionWithFirstPage = z.object({
+//   id: z.string().url(),
+//   type: CollectionType,
+//   first: createCollectionPageSchema(z.any()), // Page of any items
+// });
+// export type OldCollectionWithFirstPage = z.infer<typeof OldCollectionWithFirstPage>;
+
+// export const OldCollectionWithItems = z.object({
+//   id: z.string().url(),
+//   type: CollectionType,
+//   totalItems: z.number().int().nonnegative(),
+//   items: z.array(z.any()),
+// });
+// export type OldCollectionWithItems = z.infer<typeof OldCollectionWithItems>;
+
+// export const OldCollection = z.union([
+//   OldCollectionWithFirstPage,
+//   OldCollectionWithItems,
+// ]);
+// export type OldCollection = z.infer<typeof OldCollection>;
+
+
+// For direct use in BaseObjectSchema where it was Collection or CollectionWithItems
+export const Collection = BaseCollection; // Alias for now
+export type Collection = BaseCollection;
+
+// If CollectionWithItems was specifically used for its structure (id, type, totalItems, items array)
+export const CollectionWithItems = createCollectionSchema(ItemSchema).pick({
+  id: true,
+  type: true,
+  totalItems: true,
+  items: true,
+  "@context": true,
 });
 export type CollectionWithItems = z.infer<typeof CollectionWithItems>;
-
-export const Collection = z.union([
-  CollectionWithFirstPage,
-  CollectionWithItems,
-]);
-export type Collection = z.infer<typeof Collection>;

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // For Note, Question, etc.
+import { Actor } from "./actor.js"; // For creating an Actor (though less common via Create by others)
+
+// The object of a Create can be any ActivityPub object or a link to one.
+const CreatedObject = z.union([
+  BaseObjectSchema, // e.g. Note, Question, Article
+  Actor,            // e.g. A new actor object being published (less common as a federated Create)
+  z.string().url()  // URL to an object (if object is already hosted elsewhere)
+]);
+
+export const CreateActivity = BaseActivity.extend({
+  type: z.literal("Create"),
+  object: CreatedObject.describe("The object that is being created."),
+  // published, to, cc are inherited from BaseActivity
+});
+
+export type CreateActivity = z.infer<typeof CreateActivity>;

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // For Tombstone or object itself
+import { Actor } from "./actor.js";
+
+// The object of a Delete is typically the object being deleted,
+// or a Tombstone representation of it.
+const DeletedObject = z.union([
+  BaseObjectSchema, // Could be a Tombstone or the object itself
+  Actor,            // Deleting an actor
+  z.string().url()  // URL to the object being deleted
+]);
+
+export const DeleteActivity = BaseActivity.extend({
+  type: z.literal("Delete"),
+  object: DeletedObject.describe("The object that is being deleted."),
+  // origin can be used to specify the original source of the object if object is a Tombstone
+});
+
+export type DeleteActivity = z.infer<typeof DeleteActivity>;

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { Actor } from "./actor.js";
+import { BaseObjectSchema } from "./note/baseContent.js";
+
+// The object of a Flag can be an Actor, a Note, or other objects, or their URIs.
+// Mastodon's example shows an array of URIs (actor and posts).
+const FlaggedObject = z.union([
+  Actor,
+  BaseObjectSchema,
+  z.string().url(),
+  z.array(z.union([Actor, BaseObjectSchema, z.string().url()])) // Support array of objects/URIs
+]);
+
+export const FlagActivity = BaseActivity.extend({
+  type: z.literal("Flag"),
+  object: FlaggedObject.describe("The object(s) being flagged (e.g., Actor, Note, or an array of these)."),
+  content: z.string().optional().describe("The comment or reason for flagging."),
+  // Mastodon example for Flag:
+  // actor: "https://mastodon.example/actor" (instance actor)
+  // content: "Please take a look at this user and their posts"
+  // object: [ "https://example.com/users/1", "https://example.com/posts/380590" ]
+  // to: "https://example.com/users/1" (the user being reported, or their instance actor)
+});
+
+export type FlagActivity = z.infer<typeof FlagActivity>;

--- a/src/follow.ts
+++ b/src/follow.ts
@@ -1,11 +1,23 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { Actor } from "./actor.js"; // Actor being followed
 
-export const ENTITY_TYPE_FOLLOW = "Follow";
-export const Follow = z.object({
-  id: z.string(),
-  type: z.literal(ENTITY_TYPE_FOLLOW),
-  actor: z.string(),
-  object: z.string(),
+// The object of a Follow activity is typically an Actor or a URL to an Actor.
+const FollowedObject = z.union([
+  z.string().url(),
+  Actor
+]);
+
+export const FollowActivity = BaseActivity.extend({
+  type: z.literal("Follow"),
+  object: FollowedObject.describe("The actor that is being followed."),
 });
 
-export type Follow = z.infer<typeof Follow>;
+export type FollowActivity = z.infer<typeof FollowActivity>;
+
+// For convenience, if Follow is used as an object itself (e.g. in Accept/Reject)
+// it might be simpler, but the full activity is usually what's exchanged.
+// The previous export `Follow` can be an alias or a simplified version if needed.
+// For now, we focus on `FollowActivity`.
+export const Follow = FollowActivity; // Alias for backward compatibility if needed
+export type Follow = FollowActivity;

--- a/src/like.ts
+++ b/src/like.ts
@@ -1,13 +1,22 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // For Note, Article, etc.
+import { Actor } from "./actor.js"; // e.g. liking a profile
 
-import { Note } from "./note.js";
+// The object of a Like can be any ActivityPub object or a link to one.
+const LikedObject = z.union([
+  z.string().url(),
+  BaseObjectSchema,
+  Actor
+]);
 
-export const ENTITY_TYPE_LIKE = "Like";
-export const Like = z.object({
-  type: z.literal(ENTITY_TYPE_LIKE),
-  id: z.string(),
-  actor: z.string(),
-  object: z.union([z.string(), Note]),
+export const LikeActivity = BaseActivity.extend({
+  type: z.literal("Like"),
+  object: LikedObject.describe("The object that is being liked."),
 });
 
-export type Like = z.infer<typeof Like>;
+export type LikeActivity = z.infer<typeof LikeActivity>;
+
+// Alias for backward compatibility or if used as an object in Undo
+export const Like = LikeActivity;
+export type Like = LikeActivity;

--- a/src/move.ts
+++ b/src/move.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { Actor } from "./actor.js"; // Actor being moved (object) and target actor
+
+// Object is the old actor. Target is the new actor.
+const MovedActor = z.union([Actor, z.string().url()]);
+
+export const MoveActivity = BaseActivity.extend({
+  type: z.literal("Move"),
+  object: MovedActor.describe("The actor that is being moved (the old account)."),
+  target: MovedActor.describe("The new actor to which the old account has moved."),
+  // Mastodon example for Move:
+  // actor: "https://mastodon.example/users/alice" (old actor URI)
+  // object: "https://mastodon.example/users/alice" (old actor URI)
+  // target: "https://alice.com/users/109835986274379" (new actor URI)
+  // to: "https://mastodon.example/users/alice/followers"
+});
+
+export type MoveActivity = z.infer<typeof MoveActivity>;

--- a/src/note.ts
+++ b/src/note.ts
@@ -1,8 +1,29 @@
 import { z } from "zod";
-import { BaseContent } from "./note/baseContent.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // Updated import name
 
-export const ENTITY_TYPE_NOTE = "Note";
-export const Note = BaseContent.extend({
-  type: z.literal(ENTITY_TYPE_NOTE),
+export const NoteType = z.literal("Note");
+export const ArticleType = z.literal("Article");
+export const PageType = z.literal("Page");
+// Other object types Mastodon might transform (Image, Audio, Video, Event)
+// These often have more specific schemas if they are primary objects,
+// but Mastodon treats incoming unknown types often by trying to make a Note-like status.
+
+export const Note = BaseObjectSchema.extend({
+  type: NoteType,
 });
 export type Note = z.infer<typeof Note>;
+
+// Article might have more specific properties, but for now, can extend BaseObjectSchema
+export const Article = BaseObjectSchema.extend({
+  type: ArticleType,
+});
+export type Article = z.infer<typeof Article>;
+
+export const Page = BaseObjectSchema.extend({
+  type: PageType,
+});
+export type Page = z.infer<typeof Page>;
+
+// If specific schemas for ImageObject, AudioObject, VideoObject, EventObject are needed
+// (distinct from attachments), they would be defined here too.
+// For now, Mastodon transforms them into statuses, so their structure would resemble Note.

--- a/src/note/attachment.ts
+++ b/src/note/attachment.ts
@@ -2,7 +2,19 @@ import { z } from "zod";
 
 import { Document } from "./document.js";
 import { PropertyValue } from "./propertyValue.js";
+import { ImageObject } from "./imageObject.js";
+import { VideoObject } from "./videoObject.js";
+import { AudioObject } from "./audioObject.js";
 
-export const Attachment = z.union([PropertyValue, Document]);
+// An attachment can be a media object (Image, Video, Audio, Document)
+// or a PropertyValue (used for profile fields, though less common as direct status attachments).
+// Link objects could also be attachments, but Mastodon uses PreviewCards for links in status text.
+export const Attachment = z.union([
+  ImageObject,
+  VideoObject,
+  AudioObject,
+  Document,
+  PropertyValue, // Kept for completeness, though less common for status media attachments.
+]);
 
 export type Attachment = z.infer<typeof Attachment>;

--- a/src/note/audioObject.ts
+++ b/src/note/audioObject.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { BaseMedia } from "./baseMedia.js";
+
+export const AudioObjectType = z.literal("Audio");
+
+export const AudioObject = BaseMedia.extend({
+  type: AudioObjectType,
+  // Duration is particularly relevant for Audio objects
+  duration: z.string().describe("The duration of the audio content (e.g., ISO 8601 duration format 'PT2M30S')").optional(),
+});
+
+export type AudioObject = z.infer<typeof AudioObject>;

--- a/src/note/baseContent.ts
+++ b/src/note/baseContent.ts
@@ -1,49 +1,79 @@
 import { z } from "zod";
 import { Attachment } from "./attachment.js";
 import { Tag } from "./tag.js";
-import { Collection } from "../collection.js";
+import { createCollectionSchema, createCollectionPageSchema, CollectionType, CollectionPageType } from "../collection.js";
+import { LikeActivity } from "../like.js"; // For likes collection items
+import { AnnounceActivity } from "../announce.js"; // For shares collection items
+import { Actor } from "../actor.js"; // For likers/sharers collection items
+import { Note } from "../note.js"; // For replies collection items
 
-export const BaseContent = z.object({
-  id: z.string(),
-  url: z
-    .string({ description: "Note URL. This is optional for Pleloma" })
-    .nullish(),
-  attributedTo: z.string({ description: "Note publisher" }),
+// Define specific item types for different collections
+const ReplyItemSchema = z.union([z.lazy(() => Note), z.string().url()]); // Note or URL to Note
+const LikeItemSchema = z.union([LikeActivity, Actor, z.string().url()]); // Like activity, Actor (liker), or URL
+const ShareItemSchema = z.union([AnnounceActivity, Actor, z.string().url()]); // Announce activity, Actor (booster), or URL
 
-  to: z.union([z.string(), z.string().array()]),
-  cc: z.union([z.string(), z.string().array()]),
+// Create specific collection schemas
+const RepliesCollectionSchema = createCollectionSchema(ReplyItemSchema);
+// For Likes/Shares, Mastodon's embedded version on a status often just has totalItems.
+// However, a full collection could also be embedded or linked.
+// The createCollectionSchema makes 'items' optional, so it can handle both.
+const LikesCollectionSchema = createCollectionSchema(LikeItemSchema);
+const SharesCollectionSchema = createCollectionSchema(ShareItemSchema);
 
-  inReplyTo: z.string().nullish(),
 
-  summary: z.string({ description: "Note short summary" }).nullish(),
-  summaryMap: z
-    .record(z.string(), { description: "Note short summary in each locale" })
-    .nullish(),
-
-  content: z
+export const BaseObjectSchema = z.object({
+  "@context": z
     .union([
-      z.string({ description: "Note content" }),
-      z.string({ description: "Note content in array from Wordpress" }).array(),
+      z.string(),
+      z.array(z.union([z.string(), z.record(z.string())])),
     ])
-    .nullish(),
-  contentMap: z
-    .union([
-      z.record(z.string(), { description: "Note content in each locale" }),
-      z
-        .string({
-          description:
-            "Some activity pub server use content map as array with content in the first element",
-        })
-        .array(),
-    ])
-    .nullish(),
-  replies: Collection.nullish(),
+    .optional()
+    .describe(
+      "The JSON-LD context. Can be a URL or an array of URLs/objects."
+    ),
+  id: z.string().url().describe("The unique URI of the object"),
+  type: z.string().describe("The type of the object (e.g., Note, Question, Article)"), // Will be narrowed in specific types
 
-  attachment: z.union([Attachment, Attachment.array()]).nullish(),
-  tag: z.union([Tag, Tag.array()]),
+  attributedTo: z.string().url().describe("URI of the actor who created this object"),
 
-  published: z.string({ description: "Object published datetime" }),
-  updated: z.string({ description: "Object updated datetime" }).nullish(),
+  content: z.string().optional().describe("The content of the object, typically HTML"),
+  contentMap: z.record(z.string()).optional().describe("A map of content per language code"),
+
+  name: z.string().optional().describe("A name or title for the object"),
+  nameMap: z.record(z.string()).optional().describe("A map of name per language code"),
+
+  summary: z.string().nullish().describe("A summary of the object (used for content warnings/spoiler text)"),
+  // summaryMap is less common for Mastodon's primary use of summary as CW, but kept for completeness
+  summaryMap: z.record(z.string()).nullish().describe("A map of summary per language code"),
+
+  sensitive: z.boolean().optional().describe("Indicates that content may be sensitive (as:sensitive)"),
+
+  inReplyTo: z.string().url().nullish().describe("URI of the object this object is in reply to"),
+
+  published: z.string().datetime({ offset: true }).describe("The date and time the object was published (ISO 8601)"),
+  updated: z.string().datetime({ offset: true }).nullish().describe("The date and time the object was last updated (ISO 8601)"),
+
+  url: z.string().url().optional().describe("A URL linking to a public representation of the object"),
+
+  to: z.array(z.string().url()).optional().describe("Audience: Actors or collections targeted for delivery"),
+  cc: z.array(z.string().url()).optional().describe("Audience: Actors or collections copied for delivery"),
+  // bto and bcc are also possible but less common for Mastodon objects themselves
+
+  tag: z.array(Tag).optional().describe("Tags associated with this object (Mentions, Hashtags, Emojis)"),
+  attachment: z.array(Attachment).optional().describe("Attached media or other objects"),
+
+  replies: z.union([z.string().url(), RepliesCollectionSchema]).nullish().describe("A collection of replies to this object. Can be a URL or an embedded collection."),
+
+  // Mastodon specific extensions for likes/shares counts on the object itself
+  // In pure ActivityPub, these are often derived from observing Like/Announce activities
+  // However, Mastodon includes them directly on the status object.
+  // These collections typically only include `totalItems` when embedded directly on a status.
+  likes: z.union([z.string().url(), LikesCollectionSchema]).nullish().describe("Collection of likes for this object. Mastodon often includes totalItems."),
+  shares: z.union([z.string().url(), SharesCollectionSchema]).nullish().describe("Collection of shares (boosts/announcements) for this object. Mastodon often includes totalItems."),
+
+  // For other potential object types Mastodon might transform
+  // duration: z.string().optional().describe("When the object describes a time-based resource (e.g. audio or video)"),
+  // mediaType: z.string().optional().describe("The MIME type of the content, if applicable"),
 });
 
-export type BaseContent = z.infer<typeof BaseContent>;
+export type BaseObjectSchema = z.infer<typeof BaseObjectSchema>;

--- a/src/note/baseMedia.ts
+++ b/src/note/baseMedia.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const BaseMedia = z.object({
+  // Type will be specialized by extending schemas (e.g., Image, Video, Audio, Document)
+  type: z.string().describe("The type of the media object"),
+  mediaType: z.string().optional().describe("The MIME type of the media content"),
+  url: z.string().url().describe("A URL link to the media content"),
+
+  name: z.string().nullish().describe("A name or title for the media object"),
+  summary: z.string().nullish().describe("A summary or description of the media object (alt text)"),
+
+  width: z.number().int().positive().optional().describe("The width of the visual media in pixels"),
+  height: z.number().int().positive().optional().describe("The height of the visual media in pixels"),
+
+  duration: z.string().optional().describe("The duration of the media content (e.g., ISO 8601 duration format like 'PT2M30S' for audio/video)"),
+
+  // Mastodon specific extensions often found on media attachments
+  blurhash: z.string().optional().describe("A BlurHash string for the media (toot:blurhash)"),
+  focalPoint: z.tuple([z.number(), z.number()]).optional().describe("Focal point coordinates [x, y] (toot:focalPoint), where x and y are between -1.0 and 1.0."),
+});
+
+export type BaseMedia = z.infer<typeof BaseMedia>;

--- a/src/note/document.ts
+++ b/src/note/document.ts
@@ -1,14 +1,17 @@
 import { z } from "zod";
+import { BaseMedia } from "./baseMedia.js"; // Import the new base
 
-export const Document = z.object({
-  type: z.literal("Document"),
-  mediaType: z.string(),
-  url: z.string(),
-  blurhash: z.string().optional(),
-  width: z.number().optional(),
-  height: z.number().optional(),
-  name: z.string().optional().nullable(),
-  focalPoint: z.tuple([z.number(), z.number()]).optional(),
+export const DocumentType = z.literal("Document");
+
+// Document can also be a type of media, but often more generic or non-visual.
+// It can still benefit from some BaseMedia properties.
+export const Document = BaseMedia.extend({
+  type: DocumentType,
+  // Override or ensure properties from BaseMedia are appropriate
+  // For a generic Document, width, height, focalPoint, blurhash might be less common
+  // but are kept if it could represent a visual document.
+  // If Document is strictly non-visual, these could be omitted or made undefined.
+  // For now, inheriting them as optional is fine.
 });
 
 export type Document = z.infer<typeof Document>;

--- a/src/note/emoji.ts
+++ b/src/note/emoji.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
-
-import { Image } from "../image.js";
+import { Image } from "../image.js"; // Image schema should have type, mediaType, url
 
 export const Emoji = z.object({
-  type: z.literal("Emoji"),
-  name: z.string(),
-  updated: z.string(),
-  icon: Image,
+  id: z.string().url().optional().describe("The unique URI of the emoji definition"),
+  type: z.literal("Emoji").describe("Indicates that this is a custom Emoji object (toot:Emoji)"),
+  name: z.string().describe("The shortcode of the emoji (e.g., :thonking:)"),
+  icon: Image.describe("An Image object representing the emoji's visual content"),
+  updated: z.string().datetime({ offset: true }).optional().describe("Timestamp of when the emoji was last updated (ISO 8601). Optional in AP tag context."),
+  // Mastodon's CustomEmoji entity (REST API) has other fields like static_url, visible_in_picker, category
+  // but for ActivityPub tags, id, type, name, icon are primary.
 });
 
 export type Emoji = z.infer<typeof Emoji>;

--- a/src/note/imageObject.ts
+++ b/src/note/imageObject.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { BaseMedia } from "./baseMedia.js";
+
+export const ImageObjectType = z.literal("Image");
+
+export const ImageObject = BaseMedia.extend({
+  type: ImageObjectType,
+});
+
+export type ImageObject = z.infer<typeof ImageObject>;

--- a/src/note/mention.ts
+++ b/src/note/mention.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 export const Mention = z.object({
-  type: z.literal("Mention"),
-  href: z.string(),
-  name: z.string(),
+  type: z.literal("Mention").describe("Indicates that this is a Mention link"),
+  href: z.string().url().describe("The URL of the mentioned actor"),
+  name: z.string().describe("The textual representation of the mention (e.g., @user@domain)"),
 });
 
 export type Mention = z.infer<typeof Mention>;

--- a/src/note/videoObject.ts
+++ b/src/note/videoObject.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { BaseMedia } from "./baseMedia.js";
+
+export const VideoObjectType = z.literal("Video");
+
+export const VideoObject = BaseMedia.extend({
+  type: VideoObjectType,
+  // Duration is particularly relevant for Video objects
+  duration: z.string().describe("The duration of the video content (e.g., ISO 8601 duration format 'PT2M30S')").optional(),
+});
+
+export type VideoObject = z.infer<typeof VideoObject>;

--- a/src/question.ts
+++ b/src/question.ts
@@ -1,12 +1,25 @@
 import { z } from "zod";
-import { BaseContent } from "./note/baseContent.js";
-import { Note } from "./question/note.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // Updated import name
+import { PollOption } from "./question/note.js"; // Renamed for clarity from just Note
 
-export const ENTITY_TYPE_QUESTION = "Question";
-export const Question = BaseContent.extend({
-  type: z.literal(ENTITY_TYPE_QUESTION),
+export const QuestionType = z.literal("Question");
 
-  endTime: z.string({ description: "Question end time" }),
-  oneOf: Note.array(),
+export const Question = BaseObjectSchema.extend({
+  type: QuestionType,
+
+  // Poll-specific properties from ActivityStreams Vocabulary & Mastodon extensions
+  endTime: z.string().datetime({ offset: true }).optional().describe("Timestamp for when voting will close on the poll (ISO 8601)"),
+  closed: z.string().datetime({ offset: true }).optional().describe("Timestamp for when voting actually closed (ISO 8601). If present, poll is closed."),
+
+  votersCount: z.number().int().nonnegative().optional().describe("How many distinct actors have voted (toot:votersCount)"),
+
+  oneOf: z.array(PollOption).optional().describe("Array of options for a single-choice poll. Each option is a Note."),
+  anyOf: z.array(PollOption).optional().describe("Array of options for a multiple-choice poll. Each option is a Note."),
+
+  // According to ActivityStreams, Question can also have 'options' which is a list of Objects.
+  // Mastodon uses oneOf/anyOf with Note objects for options.
+}).refine(data => data.oneOf || data.anyOf, {
+  message: "A Question (poll) must have either 'oneOf' or 'anyOf' options.",
 });
+
 export type Question = z.infer<typeof Question>;

--- a/src/question/note.ts
+++ b/src/question/note.ts
@@ -1,12 +1,23 @@
 import { z } from "zod";
+import { CollectionWithItems } from "../collection.js"; // For replies.totalItems
 
-export const Note = z.object({
-  type: z.literal("Note"),
-  name: z.string(),
-  replies: z.object({
-    type: z.literal("Collection"),
-    totalItems: z.number(),
-  }),
+// Represents an option within a Question (Poll) object.
+// As per ActivityStreams Vocabulary §5.4 and Mastodon's implementation,
+// these are typically represented as Note objects.
+export const PollOption = z.object({
+  // id: z.string().url().optional().describe("Unique URI for the poll option, if it has one"), // Not always present in Mastodon's examples
+  type: z.literal("Note").describe("The type of the poll option, typically Note"),
+  name: z.string().describe("The text content of the poll option"),
+
+  // Mastodon uses replies.totalItems to represent the vote count for this option.
+  // In pure ActivityStreams, this might be a collection of activities (e.g., Create activities whose object is this option).
+  replies: CollectionWithItems.extend({ // Make sure CollectionWithItems has totalItems
+    items: z.undefined().optional(), // Votes are usually not itemized directly on the poll option in this context
+  }).optional().describe("A collection representing votes for this option. totalItems indicates the vote count."),
+
+  // Potentially, an option could have its own attachments or tags, though uncommon for polls.
+  // attachment: z.array(Attachment).optional(),
+  // tag: z.array(Tag).optional(),
 });
 
-export type Note = z.infer<typeof Note>;
+export type PollOption = z.infer<typeof PollOption>;

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -1,12 +1,18 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { FollowActivity } from "./follow.js"; // Typically rejecting a Follow activity
+import { BaseObjectSchema } from "./note/baseContent.js"; // Or a more generic object/link type
 
-import { Follow } from "./follow.js";
+// Object being rejected, commonly a FollowActivity or an Offer.
+const RejectedObject = z.union([
+  FollowActivity,
+  BaseObjectSchema, // e.g. rejecting an Offer activity
+  z.string().url()
+]);
 
-export const Reject = z.object({
-  id: z.string(),
-  actor: z.string(),
+export const RejectActivity = BaseActivity.extend({
   type: z.literal("Reject"),
-  object: Follow,
+  object: RejectedObject.describe("The object that was rejected (e.g., a Follow activity)."),
 });
 
-export type Reject = z.infer<typeof Reject>;
+export type RejectActivity = z.infer<typeof RejectActivity>;

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js";
+import { Actor } from "./actor.js";
+import { Collection } from "./collection.js"; // Origin/target is often a collection
+
+const RemovedObject = z.union([BaseObjectSchema, Actor, z.string().url()]);
+const OriginCollection = z.union([Collection, z.string().url()]);
+
+export const RemoveActivity = BaseActivity.extend({
+  type: z.literal("Remove"),
+  object: RemovedObject.describe("The object being removed."),
+  origin: OriginCollection.optional().describe("The collection from which the object is being removed."),
+  // 'target' could also be used if 'origin' is not appropriate for the context
+});
+
+export type RemoveActivity = z.infer<typeof RemoveActivity>;

--- a/src/undo.ts
+++ b/src/undo.ts
@@ -1,13 +1,25 @@
 import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { FollowActivity } from "./follow.js";
+import { LikeActivity } from "./like.js";
+import { AnnounceActivity } from "./announce.js";
+import { BlockActivity } from "./block.js"; // Assuming BlockActivity will be created
 
-import { Follow } from "./follow.js";
-import { Like } from "./like.js";
+// The object of an Undo is the activity that is being undone.
+// This can be any other activity.
+const UndoneActivity = z.union([
+  FollowActivity,
+  LikeActivity,
+  AnnounceActivity,
+  z.lazy(() => BlockActivity), // Use lazy if BlockActivity is in a separate file and might cause circular deps
+  // Potentially any BaseActivity, but often specific ones are undone.
+  BaseActivity,
+  z.string().url() // URL to an activity
+]);
 
-export const Undo = z.object({
-  id: z.string(),
-  actor: z.string(),
+export const UndoActivity = BaseActivity.extend({
   type: z.literal("Undo"),
-  object: z.union([Like, Follow]),
+  object: UndoneActivity.describe("The activity that is being undone."),
 });
 
-export type Undo = z.infer<typeof Undo>;
+export type UndoActivity = z.infer<typeof UndoActivity>;

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { BaseActivity } from "./activity.js";
+import { BaseObjectSchema } from "./note/baseContent.js"; // For Note, Question, Article, etc.
+import { Actor } from "./actor.js"; // For updating an Actor profile
+
+// The object of an Update is the full new representation of the object.
+const UpdatedObject = z.union([
+  BaseObjectSchema,
+  Actor,
+  z.string().url() // Should resolve to the new state of the object
+]);
+
+export const UpdateActivity = BaseActivity.extend({
+  type: z.literal("Update"),
+  object: UpdatedObject.describe("The object that is being updated, with its new state."),
+});
+
+export type UpdateActivity = z.infer<typeof UpdateActivity>;


### PR DESCRIPTION
This commit introduces a comprehensive set of Zod schemas for Mastodon's ActivityPub entities and activities.

Key additions and enhancements include:

-   **Actor Model (`src/actor.ts`):** Expanded to cover more ActivityPub
    properties and Mastodon-specific extensions like `featured`,
    `featuredTags`, `discoverable`, `indexable`, `suspended`, `memorial`,
    and profile `attachment` (PropertyValue).
-   **Object Models (`src/note/baseContent.ts`, `src/note.ts`, `src/question.ts`):**
    Refined `BaseObjectSchema` and specialized `Note`, `Article`, `Page`,
    and `Question` (for polls), including `sensitive`, `likes`/`shares`
    collections, and detailed poll properties.
-   **Media Attachments (`src/note/baseMedia.ts`, etc.):** Introduced
    `BaseMedia` and specific `ImageObject`, `VideoObject`, `AudioObject`,
    `Document` schemas with properties like `summary` (alt text), `duration`,
    `blurhash`, and `focalPoint`.
-   **Tags (`src/note/mention.ts`, `emoji.ts`, etc.):** Updated `Mention`
    and `Emoji` schemas for better alignment with ActivityPub practices.
-   **Collections (`src/collection.ts`):** Implemented generic helper
    functions (`createCollectionSchema`, `createCollectionPageSchema`)
    for building typed collections and pages, used for `replies`, `likes`,
    `shares`, etc.
-   **Activities (`src/activity.ts` and individual files):** Created a
    `BaseActivity` schema and numerous specific activity schemas (Create,
    Delete, Update, Follow, Like, Announce, Add, Remove, Block, Flag, Move,
    Accept, Reject, Undo) extending it.

These schemas provide a strong foundation for parsing and validating ActivityPub data corresponding to Mastodon's implementation.