### PR TITLE
Fix visibility enum (use `unlisted`) and bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llun/activities.schema",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Validate ActivityPub and Mastodon with Zod",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/mastodon/visibility.ts
+++ b/src/mastodon/visibility.ts
@@ -1,5 +1,5 @@
 // This schema is base on https://docs.joinmastodon.org/entities/Status/#visibility
 import { z } from "zod";
 
-export const Visibility = z.enum(["public", "unlist", "private", "direct"]);
+export const Visibility = z.enum(["public", "unlisted", "private", "direct"]);
 export type Visibility = z.infer<typeof Visibility>;


### PR DESCRIPTION
### Motivation
- The Mastodon `visibility` enum used `unlist` which is inconsistent with the Mastodon API spec that uses `unlisted`.
- The package version needs a minor bump to reflect the backwards-compatible change.

### Description
- Correct the `Visibility` enum value in `src/mastodon/visibility.ts` from `unlist` to `unlisted`.
- Bump the package version in `package.json` from `0.3.1` to `0.4.0`.
- Changes are limited to the Mastodon schema and package metadata and do not alter other schemas.

### Testing
- No automated tests were run for this change.
- No test failures reported because tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b79e8ccc83289b3b62d62fe3e71e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Mastodon visibility schema with the API and updates package metadata.
> 
> - Fixes `Visibility` enum in `src/mastodon/visibility.ts`, changing `"unlist"` to `"unlisted"`
> - Bumps `package.json` version from `0.3.1` to `0.4.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92bd93275213815f2a3538a64ec9296d35273fc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->